### PR TITLE
Adds support for use of AWSCredentials

### DIFF
--- a/Rebus.AmazonSQS/Config/AmazonSQSConfigurationExtensions.cs
+++ b/Rebus.AmazonSQS/Config/AmazonSQSConfigurationExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using Amazon;
+using Amazon.Runtime;
 using Amazon.SQS;
 using Rebus.AmazonSQS;
 using Rebus.Logging;
@@ -20,6 +21,32 @@ namespace Rebus.Config
         /// <summary>
         /// Configures Rebus to use Amazon Simple Queue Service as the message transport
         /// </summary>
+        public static void UseAmazonSqs(this StandardConfigurer<ITransport> configurer, AWSCredentials credentials, AmazonSQSConfig config, string inputQueueAddress)
+        {
+            configurer.Register(c =>
+            {
+                var rebusLoggerFactory = c.Get<IRebusLoggerFactory>();
+                var asyncTaskFactory = c.Get<IAsyncTaskFactory>();
+
+                return new AmazonSqsTransport(inputQueueAddress, credentials, config, rebusLoggerFactory, asyncTaskFactory);
+            });
+
+            configurer
+                .OtherService<IPipeline>()
+                .Decorate(p =>
+                {
+                    var pipeline = p.Get<IPipeline>();
+
+                    return new PipelineStepRemover(pipeline)
+                        .RemoveIncomingStep(s => s.GetType() == typeof(HandleDeferredMessagesStep));
+                });
+
+            configurer.OtherService<ITimeoutManager>().Register(c => new DisabledTimeoutManager(), description: SqsTimeoutManagerText);
+        }
+
+        /// <summary>
+        /// Configures Rebus to use Amazon Simple Queue Service as the message transport
+        /// </summary>
         public static void UseAmazonSqs(this StandardConfigurer<ITransport> configurer, string accessKeyId, string secretAccessKey, RegionEndpoint reguEndpoint, string inputQueueAddress)
         {
             UseAmazonSqs(configurer, accessKeyId, secretAccessKey, new AmazonSQSConfig { RegionEndpoint = reguEndpoint }, inputQueueAddress );
@@ -30,25 +57,7 @@ namespace Rebus.Config
         /// </summary>
         public static void UseAmazonSqs(this StandardConfigurer<ITransport> configurer, string accessKeyId, string secretAccessKey, AmazonSQSConfig config, string inputQueueAddress)
         {
-            configurer.Register(c =>
-            {
-                var rebusLoggerFactory = c.Get<IRebusLoggerFactory>();
-                var asyncTaskFactory = c.Get<IAsyncTaskFactory>();
-
-                return new AmazonSqsTransport(inputQueueAddress, accessKeyId, secretAccessKey, config, rebusLoggerFactory, asyncTaskFactory);
-            });
-
-            configurer
-                .OtherService<IPipeline>()
-                .Decorate(p =>
-                {
-                    var pipeline = p.Get<IPipeline>();
-
-                    return new PipelineStepRemover(pipeline)
-                        .RemoveIncomingStep(s => s.GetType() == typeof (HandleDeferredMessagesStep));
-                });
-
-            configurer.OtherService<ITimeoutManager>().Register(c => new DisabledTimeoutManager(), description: SqsTimeoutManagerText);
+            UseAmazonSqs(configurer, new BasicAWSCredentials(accessKeyId, secretAccessKey), config, inputQueueAddress);
         }
 
         /// <summary>
@@ -64,12 +73,20 @@ namespace Rebus.Config
         /// </summary>
         public static void UseAmazonSqsAsOneWayClient(this StandardConfigurer<ITransport> configurer, string accessKeyId, string secretAccessKey, AmazonSQSConfig amazonSqsConfig)
         {
+            UseAmazonSqsAsOneWayClient(configurer, new BasicAWSCredentials(accessKeyId, secretAccessKey), amazonSqsConfig);
+        }
+
+        /// <summary>
+        /// Configures Rebus to use Amazon Simple Queue Service as the message transport
+        /// </summary>
+        private static void UseAmazonSqsAsOneWayClient(StandardConfigurer<ITransport> configurer, AWSCredentials credentials, AmazonSQSConfig amazonSqsConfig)
+        {
             configurer.Register(c =>
             {
                 var rebusLoggerFactory = c.Get<IRebusLoggerFactory>();
                 var asyncTaskFactory = c.Get<IAsyncTaskFactory>();
 
-                return new AmazonSqsTransport(null, accessKeyId, secretAccessKey, amazonSqsConfig, rebusLoggerFactory, asyncTaskFactory);
+                return new AmazonSqsTransport(null, credentials, amazonSqsConfig, rebusLoggerFactory, asyncTaskFactory);
             });
 
             OneWayClientBackdoor.ConfigureOneWayClient(configurer);


### PR DESCRIPTION
Adds support for use of AWSCredentials implementation instead of just access key and secret key (BasicAWSCredentials).

---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
