### PR TITLE
Change Casing of packages

### DIFF
--- a/Rebus.AmazonSQS/Rebus.AmazonSQS.csproj
+++ b/Rebus.AmazonSQS/Rebus.AmazonSQS.csproj
@@ -48,7 +48,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="awssdk.sqs" Version="3.3.1.10" />
-    <PackageReference Include="rebus" Version="4.0.0-b05" />
+    <PackageReference Include="Rebus" Version="4.0.0-b05" />
   </ItemGroup>
   <Target Name="PreBuild" BeforeTargets="PreBuildEvent">
     <Exec Command="$(ProjectDir)..\scripts\patch_assemblyinfo.cmd $(ProjectDir)" />


### PR DESCRIPTION
Hi,

This pull request will correct the casing of the Package References for Rebus. Also see issue #7 

Kind Regards
  Rob 

---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
