### PR TITLE
Add option to skip creation of queues during initialization

### DIFF
--- a/Rebus.AmazonSQS/AmazonSQS/AmazonSqsTransport.cs
+++ b/Rebus.AmazonSQS/AmazonSQS/AmazonSqsTransport.cs
@@ -88,9 +88,7 @@ namespace Rebus.AmazonSQS
         public void Initialize()
         {
             if (Address == null) return;
-
-            CreateQueue(Address);
-
+            if (_options.CreateQueues) CreateQueue(Address);
             _queueUrl = GetInputQueueUrl();
         }
 

--- a/Rebus.AmazonSQS/Config/AmazonSQSTransportOptions.cs
+++ b/Rebus.AmazonSQS/Config/AmazonSQSTransportOptions.cs
@@ -24,12 +24,19 @@ namespace Rebus.Config
         public bool UseNativeDeferredMessages { get; set; }
 
         /// <summary>
+        /// Configures whether Rebus is in control to create queues or not. If set to false, Rebus expects that the queue's are already created. 
+        /// Defaults to <code>true</code>.
+        /// </summary>
+        public bool CreateQueues {get;set;}
+
+        /// <summary>
         /// Default constructor of the exposed SQS transport options.
         /// </summary>
         public AmazonSQSTransportOptions()
         {
             ReceiveWaitTimeSeconds = 1;
             UseNativeDeferredMessages = true;
+            CreateQueues = true;
         }
     }
 }


### PR DESCRIPTION
Add options to skip creation of queues. 

For the project where we are working on, queue's are already created in AWS. The application role in AWS where the application is running in doesn't have the permission to change the infrastructure in AWS. 

---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
