### PR TITLE
Add additional UseAmazonSQSAsOneWayClient method signatures

### DIFF
--- a/Rebus.AmazonSQS/Config/AmazonSQSConfigurationExtensions.cs
+++ b/Rebus.AmazonSQS/Config/AmazonSQSConfigurationExtensions.cs
@@ -70,6 +70,24 @@ namespace Rebus.Config
             ConfigureOneWayClient(configurer, credentials, amazonSqsConfig, options ?? new AmazonSQSTransportOptions());
         }
 
+        /// <summary>
+        /// Configures Rebus to use Amazon Simple Queue Service as the message transport
+        /// </summary>
+        public static void UseAmazonSQSAsOneWayClient(this StandardConfigurer<ITransport> configurer, AWSCredentials credentials, AmazonSQSConfig config, AmazonSQSTransportOptions options = null)
+        {
+            ConfigureOneWayClient(configurer, credentials, config, options ?? new AmazonSQSTransportOptions());
+        }
+
+        /// <summary>
+        /// Configures Rebus to use Amazon Simple Queue Service as the message transport
+        /// </summary>
+        public static void UseAmazonSQSAsOneWayClient(this StandardConfigurer<ITransport> configurer, AWSCredentials credentials, RegionEndpoint regionEndpoint, AmazonSQSTransportOptions options = null)
+        {
+            var config = new AmazonSQSConfig { RegionEndpoint = regionEndpoint };
+
+            ConfigureOneWayClient(configurer, credentials, config, options ?? new AmazonSQSTransportOptions());
+        }
+
         static void Configure(StandardConfigurer<ITransport> configurer, AWSCredentials credentials, AmazonSQSConfig config, string inputQueueAddress, AmazonSQSTransportOptions options)
         {
             if (configurer == null) throw new ArgumentNullException(nameof(configurer));


### PR DESCRIPTION
Just a couple of additional UseAmazonSQSAsOneWayClient methods that allow AWSCredentials to be provided.
---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
