### PR TITLE
Update aws sdk, rebus and add AWSSDK.SecurityToken

### DIFF
--- a/Rebus.AmazonSQS.Tests/Rebus.AmazonSQS.Tests.csproj
+++ b/Rebus.AmazonSQS.Tests/Rebus.AmazonSQS.Tests.csproj
@@ -28,7 +28,7 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Rebus.AmazonSQS\Rebus.AmazonSQS.csproj" />
-    <PackageReference Include="awssdk.sqs" Version="3.3.102.128" />
+    <PackageReference Include="awssdk.sqs" Version="3.3.103" />
     <PackageReference Include="microsoft.net.test.sdk" Version="16.6.1" />
     <PackageReference Include="nunit" Version="3.12.0" />
     <PackageReference Include="nunit3testadapter" Version="3.16.1">

--- a/Rebus.AmazonSQS.Tests/Rebus.AmazonSQS.Tests.csproj
+++ b/Rebus.AmazonSQS.Tests/Rebus.AmazonSQS.Tests.csproj
@@ -28,14 +28,14 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Rebus.AmazonSQS\Rebus.AmazonSQS.csproj" />
-    <PackageReference Include="awssdk.sqs" Version="3.3.3.14" />
-    <PackageReference Include="microsoft.net.test.sdk" Version="16.4.0" />
+    <PackageReference Include="awssdk.sqs" Version="3.3.102.128" />
+    <PackageReference Include="microsoft.net.test.sdk" Version="16.6.1" />
     <PackageReference Include="nunit" Version="3.12.0" />
     <PackageReference Include="nunit3testadapter" Version="3.16.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="rebus" Version="6.0.0" />
+    <PackageReference Include="rebus" Version="6.3.1" />
     <PackageReference Include="rebus.tests.contracts" Version="6.0.0" />
   </ItemGroup>
   <ItemGroup>

--- a/Rebus.AmazonSQS/Rebus.AmazonSQS.csproj
+++ b/Rebus.AmazonSQS/Rebus.AmazonSQS.csproj
@@ -42,8 +42,9 @@
     <None Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="awssdk.sqs" Version="3.3.3.14" />
-    <PackageReference Include="Rebus" Version="6.0.0" />
+    <PackageReference Include="AWSSDK.SecurityToken" Version="3.3.105.17" />
+    <PackageReference Include="awssdk.sqs" Version="3.3.102.128" />
+    <PackageReference Include="Rebus" Version="6.3.1" />
   </ItemGroup>
   <Target Name="PreBuild" BeforeTargets="PreBuildEvent">
     <Exec Command="$(ProjectDir)..\scripts\patch_assemblyinfo.cmd $(ProjectDir)" />

--- a/Rebus.AmazonSQS/Rebus.AmazonSQS.csproj
+++ b/Rebus.AmazonSQS/Rebus.AmazonSQS.csproj
@@ -43,7 +43,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="AWSSDK.SecurityToken" Version="3.3.105.17" />
-    <PackageReference Include="awssdk.sqs" Version="3.3.102.128" />
+    <PackageReference Include="awssdk.sqs" Version="3.3.103" />
     <PackageReference Include="Rebus" Version="6.3.1" />
   </ItemGroup>
   <Target Name="PreBuild" BeforeTargets="PreBuildEvent">


### PR DESCRIPTION
Hi, I a Brazilian developer.
I use rebus in my projects, recently I came across a problem when using rebus inside a Kubernetes pod that uses SA for authentication in SQS, but the SDK version at rebus was outdated and didn't support this type of authentication. So I updated the SDK and added one more security SDK (AWSSDK.SecurityToken) so that it is possible to use the method "AssumeRoleWithWebIdentityCredentials.FromEnvironmentVariables()"
