### PR TITLE
Updated AWS dependencies and fixed warning alert.

### DIFF
--- a/Rebus.AmazonSQS.Tests/Bugs/CanStartWithDefaultCredsAndRegion.cs
+++ b/Rebus.AmazonSQS.Tests/Bugs/CanStartWithDefaultCredsAndRegion.cs
@@ -23,7 +23,11 @@ namespace Rebus.AmazonSQS.Tests.Bugs
 
             Using(activator);
 
-            activator.Handle<string>( async str => await Task.FromResult(gotTheString.Set()));
+            activator.Handle<string>(str =>
+            {
+                gotTheString.Set();
+                return Task.CompletedTask;
+            });
 
             Configure.With(activator)
                 .Transport(t =>

--- a/Rebus.AmazonSQS.Tests/Bugs/CanStartWithDefaultCredsAndRegion.cs
+++ b/Rebus.AmazonSQS.Tests/Bugs/CanStartWithDefaultCredsAndRegion.cs
@@ -23,7 +23,7 @@ namespace Rebus.AmazonSQS.Tests.Bugs
 
             Using(activator);
 
-            activator.Handle<string>(async str => gotTheString.Set());
+            activator.Handle<string>( async str => await Task.FromResult(gotTheString.Set()));
 
             Configure.With(activator)
                 .Transport(t =>

--- a/Rebus.AmazonSQS.Tests/Rebus.AmazonSQS.Tests.csproj
+++ b/Rebus.AmazonSQS.Tests/Rebus.AmazonSQS.Tests.csproj
@@ -28,10 +28,10 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Rebus.AmazonSQS\Rebus.AmazonSQS.csproj" />
-    <PackageReference Include="awssdk.sqs" Version="3.3.103" />
+    <PackageReference Include="awssdk.sqs" Version="3.3.103.21" />
     <PackageReference Include="microsoft.net.test.sdk" Version="16.6.1" />
     <PackageReference Include="nunit" Version="3.12.0" />
-    <PackageReference Include="nunit3testadapter" Version="3.16.1">
+    <PackageReference Include="nunit3testadapter" Version="3.17.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Rebus.AmazonSQS/Rebus.AmazonSQS.csproj
+++ b/Rebus.AmazonSQS/Rebus.AmazonSQS.csproj
@@ -42,8 +42,8 @@
     <None Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.SecurityToken" Version="3.3.105.17" />
-    <PackageReference Include="awssdk.sqs" Version="3.3.103" />
+    <PackageReference Include="AWSSDK.SecurityToken" Version="3.3.105.38" />
+    <PackageReference Include="awssdk.sqs" Version="3.3.103.21" />
     <PackageReference Include="Rebus" Version="6.3.1" />
   </ItemGroup>
   <Target Name="PreBuild" BeforeTargets="PreBuildEvent">


### PR DESCRIPTION
- Updated AWS dependencies.
- Fixed warning alert to "async method lacks 'await' operators" in  CanStartWithDefaultCredsAndRegion class
- Updated nunit3testadapter