### PR TITLE
MessageBatchSize (0-10)

### DIFF
--- a/Rebus.AmazonSQS/AmazonSQS/AmazonSqsTransport.cs
+++ b/Rebus.AmazonSQS/AmazonSQS/AmazonSqsTransport.cs
@@ -284,7 +284,7 @@ namespace Rebus.AmazonSQS
 
                         var destinationUrl = GetDestinationQueueUrlByName(batch.Key);
 
-                        foreach (var batchToSend in entries.Batch(10))
+                        foreach (var batchToSend in entries.Batch(_options.MessageBatchSize))
                         {
                             var request = new SendMessageBatchRequest(destinationUrl, batchToSend);
                             var response = await _client.SendMessageBatchAsync(request);

--- a/Rebus.AmazonSQS/Config/AmazonSQSTransportOptions.cs
+++ b/Rebus.AmazonSQS/Config/AmazonSQSTransportOptions.cs
@@ -46,10 +46,10 @@ namespace Rebus.Config
             }
             set
             {
-                if (value > 0 && value <= 10)
-                {
-                    _messageBatchSize = value;
-                }
+                if (value == ushort.MinValue || value > 10)
+                    throw new ArgumentOutOfRangeException(nameof(MessageBatchSize), "MessageBatchSize must be between 1 and 10.");
+
+                _messageBatchSize = value;
             }
         }
 

--- a/Rebus.AmazonSQS/Config/AmazonSQSTransportOptions.cs
+++ b/Rebus.AmazonSQS/Config/AmazonSQSTransportOptions.cs
@@ -9,6 +9,8 @@ namespace Rebus.Config
     /// </summary>
     public class AmazonSQSTransportOptions
     {
+        private ushort _messageBatchSize = 10;
+
         /// <summary>
         /// Sets the WaitTimeSeconds on the ReceiveMessage. The default setting is 1, which enables long
         /// polling for a single second. The number of seconds can be set up to 20 seconds. 
@@ -30,6 +32,26 @@ namespace Rebus.Config
         /// Defaults to <code>true</code>.
         /// </summary>
         public bool CreateQueues { get; set; }
+
+        /// <summary>
+        /// Sets the MessageBatchSize for sending batch messages to SQS. 
+        /// Value of BatchSize can be set up to 10.
+        /// Defaults to <code>10</code>.
+        /// </summary>
+        public ushort MessageBatchSize
+        {
+            get
+            {
+                return _messageBatchSize;
+            }
+            set
+            {
+                if (value > 0 && value <= 10)
+                {
+                    _messageBatchSize = value;
+                }
+            }
+        }
 
         /// <summary>
         /// Default constructor of the exposed SQS transport options.

--- a/Rebus.AmazonSQS/Config/AmazonSQSTransportOptions.cs
+++ b/Rebus.AmazonSQS/Config/AmazonSQSTransportOptions.cs
@@ -47,7 +47,7 @@ namespace Rebus.Config
             set
             {
                 if (value == ushort.MinValue || value > 10)
-                    throw new ArgumentOutOfRangeException(nameof(MessageBatchSize), "MessageBatchSize must be between 1 and 10.");
+                    throw new ArgumentOutOfRangeException(nameof(MessageBatchSize), value, "MessageBatchSize must be between 1 and 10.");
 
                 _messageBatchSize = value;
             }


### PR DESCRIPTION
Provides the possibility to define the size of a message batch.
For now I limited the option to a max size of 10 (which is the default as well).

---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
