### PR TITLE
#35 A message received from SQS just after bus disposal is made invisible in SQS

### DIFF
--- a/Rebus.AmazonSQS/AmazonSQS/AmazonSqsTransport.cs
+++ b/Rebus.AmazonSQS/AmazonSQS/AmazonSqsTransport.cs
@@ -370,7 +370,7 @@ namespace Rebus.AmazonSQS
                 MessageAttributeNames = new List<string>(new[] { "All" })
             };
 
-            var response = await _client.ReceiveMessageAsync(request, cancellationToken);
+            var response = await _client.ReceiveMessageAsync(request, CancellationToken.None);
 
             if (!response.Messages.Any()) return null;
 


### PR DESCRIPTION
Passing `CancellationToken.None` into Amazon SQS client `ReceiveMessageAsync()` in order to stop cancelling the receive which results in the socket not being closed immediately and being able to receive a message from SQS which is not handled and is marked as invisible in SQS
