### PR TITLE
Adding required AWS security policies to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,45 @@ Provides an [Amazon SQS](https://aws.amazon.com/sqs/) transport for [Rebus](http
 ---
 
 
+# Required AWS security policies
+The policy required for receiving messages from a SQS queue using "least-privilege principle" is as follows:
+```
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "sqs:DeleteMessage",
+                "sqs:GetQueueUrl",
+                "sqs:ChangeMessageVisibility",
+                "sqs:DeleteMessageBatch",
+                "sqs:SendMessageBatch",
+                "sqs:ReceiveMessage",
+                "sqs:DeleteQueue",
+                "sqs:CreateQueue",
+                "sqs:SetQueueAttributes"
+            ],
+            "Resource": "[Your SQS incoming queue and DLQ arn here]"
+        }
+    ]
+}
+```
+Note that the last three actions(`sqs:DeleteQueue`, `sqs:CreateQueue` and `sqs:SetQueueAttribute`) is only required if `AmazonSQSTransportOptions.CreateQueue` is set to `true`, otherwise they could/should be omitted. It is the default behaviour that CreateQueue is set to true, hence they are included in the above ACL.
+
+To be able to send to a queue the following permissions are required on the target queue:
+```
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "sqs:GetQueueUrl",
+                "sqs:SendMessageBatch",
+            ],
+            "Resource": "[Your SQS outgoing target queue arn here]"
+        }
+    ]
+}
+```


### PR DESCRIPTION
---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
